### PR TITLE
Extend for RDS cluster usage

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,9 @@
+locals {
+  username = var.db_instance != null ? var.db_instance.username : var.rds_cluster.master_username
+  password = var.db_instance != null ? var.db_instance.password : var.rds_cluster.master_password
+  server   = var.db_instance != null ? var.db_instance.address : var.rds_cluster.endpoint
+}
+
 resource "aws_secretsmanager_secret" "this" {
   name        = "${var.name_prefix}.database_url"
   description = "Secret value is managed via Terraform"
@@ -8,5 +14,5 @@ resource "aws_secretsmanager_secret" "this" {
 resource "aws_secretsmanager_secret_version" "this" {
   secret_id = aws_secretsmanager_secret.this.arn
 
-  secret_string = "${var.protocol}://${var.db_instance.username}:${var.db_instance.password}@${var.db_instance.address}/${var.database_name}"
+  secret_string = "${var.protocol}://${local.username}:${local.password}@${local.server}/${var.database_name}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,7 @@
 variable "database_name" {
   type = string
 
-  description = "Name of the database on `var.db_instance` to be used in the `DATABASE_URL`."
+  description = "Name of the database on to be used in the `DATABASE_URL`."
 }
 
 variable "db_instance" {
@@ -10,6 +10,8 @@ variable "db_instance" {
     password = string
     username = string
   })
+
+  default = null
 
   description = "Database instance to be used in the `DATABASE_URL`."
 }
@@ -24,6 +26,18 @@ variable "protocol" {
   type = string
 
   description = "Protocol to be used in the `DATABASE_URL`."
+}
+
+variable "rds_cluster" {
+  type = object({
+    master_username = string
+    master_password = string
+    endpoint        = string
+  })
+
+  default = null
+
+  description = "Database cluster to be used in the `DATABASE_URL`."
 }
 
 variable "tags" {


### PR DESCRIPTION
Add `rds_cluster` attribute to be not only usable for RDS instances.