### PR TITLE
Update licence with new company name for terraform-aws-secretsmanager-for-database-url

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2021 Lesson Nine GmbH
+Copyright 2021 Babbel GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 


### PR DESCRIPTION
Update licence with new company name for terraform-aws-secretsmanager-for-database-url