### PR TITLE
Relax version constraints for modules

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3, < 5"
+      version = ">= 3"
     }
   }
 }


### PR DESCRIPTION
Remove upper boundary as version upgrades need to be tested when applying the root modules anyway.