### PR TITLE
Add support for resource-specific tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,6 @@ module "secretsmanager-for-database-url" {
   db_instance   = aws_db_instance.example
   database_name = "example"
   protocol      = "mysql2"
-
-  tags = {
-    app = "example"
-    env = "production"
-  }
 }
 ```
 
@@ -36,11 +31,6 @@ module "secretsmanager-for-database-url" {
   rds_cluster   = aws_rds_cluster.example
   database_name = "example"
   protocol      = "mysql2"
-
-  tags = {
-    app = "example"
-    env = "production"
-  }
 }
 ```
 

--- a/_test/main.tf
+++ b/_test/main.tf
@@ -16,7 +16,7 @@ module "secretsmanager" {
   database_name = "example"
   protocol      = "mysql2"
 
-  tags = {
+  default_tags = {
     app = "example"
     env = "production"
   }

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ resource "aws_secretsmanager_secret" "this" {
   name        = "${var.name_prefix}.database_url"
   description = "Secret value is managed via Terraform"
 
-  tags = var.tags
+  tags = merge(var.default_tags, var.secretsmanager_secret_tags)
 }
 
 resource "aws_secretsmanager_secret_version" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,18 @@
+variable "default_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to all AWS resources created by this module.
+EOS
+}
+
 variable "database_name" {
   type = string
 
-  description = "Name of the database on to be used in the `DATABASE_URL`."
+  description = <<EOS
+Name of the database on to be used in the `DATABASE_URL`.
+EOS
 }
 
 variable "db_instance" {
@@ -10,22 +21,27 @@ variable "db_instance" {
     password = string
     username = string
   })
-
   default = null
 
-  description = "Database instance to be used in the `DATABASE_URL`."
+  description = <<EOS
+Database instance to be used in the `DATABASE_URL`.
+EOS
 }
 
 variable "name_prefix" {
   type = string
 
-  description = "Name prefix for the SecretsManager. The full name will be $${var.name_prefix}.database_url."
+  description = <<EOS
+Name prefix for the SecretsManager. The full name will be $${var.name_prefix}.database_url.
+EOS
 }
 
 variable "protocol" {
   type = string
 
-  description = "Protocol to be used in the `DATABASE_URL`."
+  description = <<EOS
+Protocol to be used in the `DATABASE_URL`.
+EOS
 }
 
 variable "rds_cluster" {
@@ -34,15 +50,18 @@ variable "rds_cluster" {
     master_password = string
     endpoint        = string
   })
-
   default = null
 
-  description = "Database cluster to be used in the `DATABASE_URL`."
+  description = <<EOS
+Database cluster to be used in the `DATABASE_URL`.
+EOS
 }
 
-variable "tags" {
+variable "secretsmanager_secret_tags" {
   type    = map(string)
   default = {}
 
-  description = "Tags which will be assigned to all resources."
+  description = <<EOS
+Map of tags assigned to the SecretsManager secret.
+EOS
 }


### PR DESCRIPTION
Breaking change: Renaming `var.tags` to `var.default_tag` in order to make it clearer that those are tags are applied to all AWS resources.