### PR TITLE
Breaking change: Rename `var.tags` to `var.default_tags`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,6 @@ module "secretsmanager-for-database-url" {
   db_instance   = aws_db_instance.example
   database_name = "example"
   protocol      = "mysql2"
-
-  tags = {
-    app = "example"
-    env = "production"
-  }
 }
 ```
 
@@ -36,11 +31,6 @@ module "secretsmanager-for-database-url" {
   rds_cluster   = aws_rds_cluster.example
   database_name = "example"
   protocol      = "mysql2"
-
-  tags = {
-    app = "example"
-    env = "production"
-  }
 }
 ```
 

--- a/_test/main.tf
+++ b/_test/main.tf
@@ -16,7 +16,7 @@ module "secretsmanager" {
   database_name = "example"
   protocol      = "mysql2"
 
-  tags = {
+  default_tags = {
     app = "example"
     env = "production"
   }

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ resource "aws_secretsmanager_secret" "this" {
   name        = "${var.name_prefix}.database_url"
   description = "Secret value is managed via Terraform"
 
-  tags = var.tags
+  tags = var.default_tags
 }
 
 resource "aws_secretsmanager_secret_version" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -19,6 +19,15 @@ Database instance to be used in the `DATABASE_URL`.
 EOS
 }
 
+variable "default_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to all AWS resources created by this module.
+EOS
+}
+
 variable "name_prefix" {
   type = string
 
@@ -45,14 +54,5 @@ variable "rds_cluster" {
 
   description = <<EOS
 Database cluster to be used in the `DATABASE_URL`.
-EOS
-}
-
-variable "tags" {
-  type    = map(string)
-  default = {}
-
-  description = <<EOS
-Map of tags assigned to all AWS resources created by this module.
 EOS
 }


### PR DESCRIPTION
This change is done to make it more clear, that tags specified via this attribute will be assigned to all AWS resources created by this module.

Also drop this attribute from the usage example in the `README.md`, as this attribute is rather for edge cases, as default tags typically specified via the `default_tags` block of the AWS provider.